### PR TITLE
Added some contrast to the dock toggler

### DIFF
--- a/index.less
+++ b/index.less
@@ -14,6 +14,7 @@
 // -------------------------------
 @import "styles/base";
 @import "styles/buttons";
+@import "styles/docks";
 @import "styles/editor";
 @import "styles/find-and-replace";
 @import "styles/forms";

--- a/styles/docks.less
+++ b/styles/docks.less
@@ -1,0 +1,12 @@
+// Nebula UI / DOCKS
+// -----------------
+// Used to style side panels
+// Overrides: atom/static/docks.less
+
+// Dock toggler
+
+.atom-dock-toggle-button {
+  .atom-dock-toggle-button-inner {
+    background-color: darken(@base-background-color, 3%);
+  }
+}


### PR DESCRIPTION
Hello,

Thanks for this great theme first ! Currently, the dock toggler is transparent (well it uses the `@base-background-color`), and doesn't have any contrast with what's around it. I'd suggest adding some !

The current one:
![screenshot from 2018-11-18 19-12-41](https://user-images.githubusercontent.com/2735603/48676376-62b4ae80-eb66-11e8-9794-ef8b9a5a7e87.png)

The one I suggest :
![screenshot from 2018-11-18 19-09-28](https://user-images.githubusercontent.com/2735603/48676387-7fe97d00-eb66-11e8-89fd-b2f1415c86ed.png) ![screenshot from 2018-11-18 19-10-37](https://user-images.githubusercontent.com/2735603/48676388-80821380-eb66-11e8-84eb-afc46181cb61.png)

A complete screenshot (toggler at the bottom) :
![screenshot from 2018-11-18 19-22-26](https://user-images.githubusercontent.com/2735603/48676439-53823080-eb67-11e8-8236-bc91332f0bd3.png)

Tell me, what do you think ? Does it fit ?